### PR TITLE
Support for floating point numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -401,7 +401,7 @@ class PDFDocumentWithTables extends PDFDocument {
           // (table width) 1o - Max size table
           w = this.page.width - this.page.margins.right - ( options.x || this.page.margins.left );
           // (table width) 2o - Size defined
-          options.width && ( w = String(options.width).replace(/[^0-9]/g,'') >> 0 );
+          options.width && ( w = parseInt(options.width) || String(options.width).replace(/[^0-9]/g,'') >> 0 );
     
           // (table width) if table is percent of page 
           // ...


### PR DESCRIPTION
When floating point numbers are put as table width, there is usually an over-exaggeration of the width due to the removal of the decimal point.