### PR TITLE
Add customHeight in cell options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+
 node_modules
 example-test
 example-promise

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,7 @@ declare module 'pdfkit-table'
 		fontSize: number;
 		fontFamily: string;
 		separation: boolean;
+		customHeight: number;
 	}
 
 	interface Data {

--- a/index.js
+++ b/index.js
@@ -364,7 +364,9 @@ class PDFDocumentWithTables extends PDFDocument {
               // apply font size on calc about height row 
               cell.hasOwnProperty('options') && prepareRowOptions(cell);
               // set customheight if has
-              customHeight = (cell.options.customHeight) ? cell.options.customHeight : 0;
+              if (cell.hasOwnProperty('options') && cell.options.hasOwnProperty("customHeight")) {
+                customHeight = (cell.options.customHeight || 0);
+              }
             }
     
             text = String(text).replace('bold:','').replace('size','');

--- a/index.js
+++ b/index.js
@@ -354,6 +354,7 @@ class PDFDocumentWithTables extends PDFDocument {
           row.forEach((cell,i) => {
     
             let text = cell;
+            let customHeight = 0;
     
             // object
             // read cell and get label of object
@@ -362,6 +363,8 @@ class PDFDocumentWithTables extends PDFDocument {
               text = String(cell.label);
               // apply font size on calc about height row 
               cell.hasOwnProperty('options') && prepareRowOptions(cell);
+              // set customheight if has
+              customHeight = (cell.options.customHeight) ? cell.options.customHeight : 0;
             }
     
             text = String(text).replace('bold:','').replace('size','');
@@ -378,7 +381,7 @@ class PDFDocumentWithTables extends PDFDocument {
               align: 'left',
             });
             
-            result = Math.max(result, cellHeight);    
+            result = Math.max(result, cellHeight, customHeight);
           });
 
           // isHeader && (result = Math.max(result, options.minRowHeight));


### PR DESCRIPTION
Adds a new option in cell options if you want a custom height for the row. Check [#42](https://github.com/natancabral/pdfkit-table/issues/42#issuecomment-1156761994).