### PR TITLE
Updated and fixed the types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,12 +18,13 @@ declare module 'pdfkit-table'
 			color: string;
 			opacity: number;
 		}
+		separation?: boolean;
 	}
 
 	export interface DataOptions {
-		fontSize: number;
-		fontFamily: string;
-		separation: boolean;
+		fontSize?: number;
+		fontFamily?: string;
+		color?: string;
 	}
 
 	export type Data = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,15 @@
 declare module 'pdfkit-table' 
 {
-	import PDFDocument from 'pdfkit';
+	import * as PDFDocument from 'pdfkit';
 
-	interface Rect {
+	export interface Rect {
 		x: number;
 		y: number;
 		width: number;
 		height: number;
 	}
 
-	interface RowOptions {
+	export interface RowOptions {
 		columnColor?: string;
 		columnOpacity?: number;
 		backgroundColor?: string;
@@ -20,20 +20,20 @@ declare module 'pdfkit-table'
 		}
 	}
 
-	interface DataOptions {
+	export interface DataOptions {
 		fontSize: number;
 		fontFamily: string;
 		separation: boolean;
 	}
 
-	type Data = {
+	export type Data = {
 		[key: string]: string | { label: string; options?: DataOptions; };
 	} | {
 		[key: string]: any;
 		options?: RowOptions;
 	};
 
-	interface Header {
+	export interface Header {
 		label?: string;
 		property?: string;
 		width?: number;
@@ -54,7 +54,7 @@ declare module 'pdfkit-table'
 		) => string;
 	}
 
-	interface Table {
+	export interface Table {
 		title?: string;
 		subtitle?: string;
 		headers?: (string | Header)[];
@@ -62,18 +62,18 @@ declare module 'pdfkit-table'
 		rows?: string[][];
 	}
 
-	interface DividerOptions {
+	export interface DividerOptions {
 		disabled?: boolean;
 		width?: number;
 		opacity?: number;
 	}
 
-	interface Divider {
+	export interface Divider {
 		header?: DividerOptions;
 		horizontal?: DividerOptions;
 	}
 
-	interface Title 
+	export interface Title 
 	{
 		label: string;
 		fontSize?: number;
@@ -81,7 +81,7 @@ declare module 'pdfkit-table'
 		color?: string; 
 	}
 
-	interface Options {
+	export interface Options {
 		title?: string | Title ;
 		subtitle?: string | Title;
 		width?: number;
@@ -104,7 +104,7 @@ declare module 'pdfkit-table'
 		) => PDFDocumentWithTables;
 	}
 
-	class PDFDocumentWithTables extends PDFDocument {
+	export class PDFDocumentWithTables extends PDFDocument {
 		public addBackground(rect: Rect, fillColor: string, fillOpacity: number, callback?: (doc: PDFDocumentWithTables) => void): void;
 		public table(table: Table, options?: Options, callback?: (doc: PDFDocumentWithTables) => void): Promise<void>;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare module 'pdfkit-table'
 			value: any,
 			indexColumn?: number,
 			indexRow?: number,
-			row?: number,
+			row?: any,
 			rectRow?: Rect,
 			rectCell?: Rect
 		) => string;
@@ -76,7 +76,7 @@ declare module 'pdfkit-table'
 		divider?: Divider;
 		columnsSize?: number[];
 		columnSpacing?: number; //default 5
-		padding?: number[]; 
+		padding?: number | number[]; 
 		addPage?: boolean; //default false
 		hideHeader?: boolean;
 		minRowHeight?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,30 @@ declare module 'pdfkit-table'
 		height: number;
 	}
 
+	interface RowOptions {
+		columnColor?: string;
+		columnOpacity?: number;
+		backgroundColor?: string;
+		backgroundOpacity?: number;
+		background?: {
+			color: string;
+			opacity: number;
+		}
+	}
+
+	interface DataOptions {
+		fontSize: number;
+		fontFamily: string;
+		separation: boolean;
+	}
+
+	type Data = {
+		[key: string]: string | { label: string; options?: DataOptions; };
+	} | {
+		[key: string]: any;
+		options?: RowOptions;
+	};
+
 	interface Header {
 		label?: string;
 		property?: string;
@@ -24,20 +48,10 @@ declare module 'pdfkit-table'
 			value: any,
 			indexColumn?: number,
 			indexRow?: number,
-			row?: any,
+			row?: Data,
 			rectRow?: Rect,
 			rectCell?: Rect
 		) => string;
-	}
-
-	interface DataOptions {
-		fontSize: number;
-		fontFamily: string;
-		separation: boolean;
-	}
-
-	interface Data {
-		[key: string]: string | { label: string; options?: DataOptions };
 	}
 
 	interface Table {
@@ -91,7 +105,8 @@ declare module 'pdfkit-table'
 	}
 
 	class PDFDocumentWithTables extends PDFDocument {
-		public table(table: Table, options?: Options): Promise<void>;
+		public addBackground(rect: Rect, fillColor: string, fillOpacity: number, callback?: (doc: PDFDocumentWithTables) => void): void;
+		public table(table: Table, options?: Options, callback?: (doc: PDFDocumentWithTables) => void): Promise<void>;
 	}
 
 	// export = PDFDocumentWithTables;


### PR DESCRIPTION
* Fixed exports so the library works properly in typescript projects.
* Fixed "Data" type, so it now properly has a typed "options" field, with the new added "RowOptions" interface, which was missing before.
* Moved "separation" from where it was wrongly listed in "DataOptions" to "RowOptions" where it belongs.
* Added missing "color" in "DataOptions" and made "fontSize" and "fontFamily" optional.
* Changed the type of "row" in header.renderer from the wrong "number" type to the correct "Data" type.
* Changed the type of "padding" in "Options" from the wrong "number[]" type to the correct "number | number[]" type.
* Added "addBackground" function, because it needs to be reachable in typescript projects.
* Added missing "callback" parameter in the "table" function.