### PR TITLE
added support for skipping header background, with headerColor: null

### DIFF
--- a/index.js
+++ b/index.js
@@ -607,7 +607,10 @@ class PDFDocumentWithTables extends PDFDocument {
                 };
 
                 // add background
-                this.addBackground(rectCell, headerColor, headerOpacity);
+                if (headerColor !== null) {
+                  // add background
+                  this.addBackground(rectCell, headerColor, headerOpacity);
+                }
     
                 // cell padding
                 cellPadding = prepareCellPadding(padding || options.padding || 0);


### PR DESCRIPTION
Before the header background was always added, no matter the settings.
Even if it was possible to make it near transparent, it was never possible to make it completely transparent.
This fixes that, and makes the header background completely optional, by setting headerColor: null