### PR TITLE
made the row separator optional, per row

### DIFF
--- a/index.js
+++ b/index.js
@@ -782,15 +782,11 @@ class PDFDocumentWithTables extends PDFDocument {
             rowBottomY = this.y + columnSpacing + (rowDistance * 2);
           }
 
-          // Separation line between rows
-          separationsRow('horizontal', startX, rowBottomY);
-    
-          // review this code
-          if( row.hasOwnProperty('options') ){
-            if( row.options.hasOwnProperty('separation') ){
-              // Separation line between rows
-              separationsRow('horizontal',startX, rowBottomY, 1, 1);
-            }
+          if( !row.hasOwnProperty('options') ||
+              !row.options.hasOwnProperty('separation') ||
+              row.options.separation !== false ){
+            // Separation line between rows
+            separationsRow('horizontal', startX, rowBottomY);
           }
     
         });


### PR DESCRIPTION
Makes it possible to turn off the row separator after a specific row by setting options.separation: false on that row.
For example if one wants to skip the separator after the last row.