### PR TITLE
bugfix: skip hardcoded titleHeight in calc if there is no title or subtitle

### DIFF
--- a/index.js
+++ b/index.js
@@ -472,9 +472,9 @@ class PDFDocumentWithTables extends PDFDocument {
           }
 
           // 24.1 is height calc title + subtitle
-          titleHeight = !lockAddTitles ? 24.1 : 0; 
+          titleHeight = ((title || subtitle) && !lockAddTitles ? 24.1 : 0);
           // calc if header + first line fit on last page
-          const calc = startY + titleHeight + firstLineHeight + this.headerHeight + safelyMarginBottom// * 1.3;
+          const calc = startY + titleHeight + firstLineHeight + headerHeight + safelyMarginBottom;// * 1.3;
 
           // content is big text (crazy!)
           if(firstLineHeight > maxY) {


### PR DESCRIPTION
The hardcoded titleHeight will mess up the height calculations if there is no title or subtitle.
It will think that cell content on last row won't fit, even though it should, just because it thinks there is a title/subtitle above the table, when there really isn't any.